### PR TITLE
[#23] Removed dependency on proxy module.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -32,7 +32,6 @@ export default {
 
   // Modules (https://go.nuxtjs.dev/config-modules)
   modules: [
-    '@nuxtjs/proxy',
     // https://go.nuxtjs.dev/bootstrap
     'bootstrap-vue/nuxt',
     'druxt-site'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@nuxtjs/google-analytics": "^2.4.0",
-    "@nuxtjs/proxy": "^2.0.1",
     "bootstrap": "^4.5.2",
     "bootstrap-vue": "^2.16.0",
     "core-js": "^3.6.5",


### PR DESCRIPTION
The DruxtSite module has a dependency on the @nuxtjs/proxy module already, so we don't need to declare an explicit dependency.