### PR TITLE
chore: update Druxt to 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "core-js": "3.18.3",
         "css-loader": "5.2.7",
         "druxt-search": "0.1.1",
-        "druxt-site": "0.10.2",
+        "druxt-site": "^0.10.3",
         "jsonapi-serializer": "3.6.7",
         "nuxt": "2.15.8",
         "vue-json-pretty": "1.8.1",
@@ -12218,9 +12218,9 @@
       }
     },
     "node_modules/druxt": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/druxt/-/druxt-0.14.0.tgz",
-      "integrity": "sha512-hMczj2prrnB4kEp8bTDJvQpYcvjRTUzbdjJuKIKmmclRkDgL8HfDKHSE0BVJPa64Jmh8sLGrIRnSkhfYJGIJNw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/druxt/-/druxt-0.15.0.tgz",
+      "integrity": "sha512-H5Q7VmXvq3naLJgRu94SsyJvQ7m3inXdvEMgLr+TpW8FEQNp3ch3oA+dPWnf2MgRpenwuzFysIWu2ZdJBr0lXw==",
       "dependencies": {
         "@nuxtjs/proxy": "^2.1.0",
         "axios": "^0.21.1",
@@ -12241,15 +12241,15 @@
       }
     },
     "node_modules/druxt-blocks": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/druxt-blocks/-/druxt-blocks-0.14.2.tgz",
-      "integrity": "sha512-zN0PPCrvU+xuBmwyisFp+hiBw4VuRtntVh7yXb/oIUpEN8xnUfF0G83Cig9Cndd3VYO+pmpOZ16tgafCwoYo0Q==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/druxt-blocks/-/druxt-blocks-0.14.3.tgz",
+      "integrity": "sha512-S4PGxEn+soGJcslNBHNPoVw90hHu6p95N44QJmVGkC5ZoI7Se/1MKylq1QTE4KVn2SZaB77m85GbACUGj94BBA==",
       "dependencies": {
         "axios": "^0.21.1",
         "drupal-jsonapi-params": "^1.1.12",
-        "druxt": "^0.14.0",
-        "druxt-entity": "^0.21.3",
-        "druxt-router": "^0.24.1"
+        "druxt": "^0.15.0",
+        "druxt-entity": "^0.21.4",
+        "druxt-router": "^0.24.2"
       },
       "optionalDependencies": {
         "vue": "^2.6.14",
@@ -12257,13 +12257,13 @@
       }
     },
     "node_modules/druxt-breadcrumb": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/druxt-breadcrumb/-/druxt-breadcrumb-0.13.2.tgz",
-      "integrity": "sha512-PMSop3QeQmsfmd4jHsWkczep7/61CEvncML1iwe8mBopH/n3j3S7KxJ6bYydJHRl8krA3JyIBoEU64GDBZjpcQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/druxt-breadcrumb/-/druxt-breadcrumb-0.13.3.tgz",
+      "integrity": "sha512-v0hmv1XPwh9pux048l307j+L2o0Fktn8eAU1t+5BJDACtbbru0Ovhei1+REk5EJteE5CIfZmVGaqpKBYyr8s4g==",
       "dependencies": {
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2",
-        "druxt-router": "^0.24.1"
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3",
+        "druxt-router": "^0.24.2"
       },
       "optionalDependencies": {
         "vue": "^2.6.14",
@@ -12271,26 +12271,26 @@
       }
     },
     "node_modules/druxt-entity": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/druxt-entity/-/druxt-entity-0.21.3.tgz",
-      "integrity": "sha512-7+9AtjyA72tTDRvDYs1fqvCisM2Rv4LJCdBlTuFX1lXoyqYiipmoF1Rc8BBYTQFNRhPrx91Exl0jzymGyJwSZQ==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/druxt-entity/-/druxt-entity-0.21.4.tgz",
+      "integrity": "sha512-d8m356ym2LBAjj59LOBkX6lxdbpNh+3/jLylPbvot/TTwkgo2KhR7Y2AlRIjEKHSCs+Re5nptm3W1WF9XcArsQ==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "drupal-jsonapi-params": "^1.2.2",
-        "druxt": "^0.14.0",
-        "druxt-router": "^0.24.1",
-        "druxt-schema": "^0.9.1"
+        "druxt": "^0.15.0",
+        "druxt-router": "^0.24.2",
+        "druxt-schema": "^0.9.2"
       }
     },
     "node_modules/druxt-menu": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/druxt-menu/-/druxt-menu-0.15.1.tgz",
-      "integrity": "sha512-d1LvMMN8lq21IA1VbveNIGmy4rld9giXzC3z/zo0O0Q2hWVZ5aj6fLXBM0UWyli2dGbXNfX84mKxDd2ojJLoZQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/druxt-menu/-/druxt-menu-0.15.2.tgz",
+      "integrity": "sha512-NzTY6gx+NkFZ9+Y8V77t9AyQvj1pdaWinqp1VeOcN6QsjHoMQ3TLKeCioLEA6qxqDZEhiwBRlHdODpItRwa6DA==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "drupal-jsonapi-params": "^1.1.12",
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2"
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3"
       },
       "optionalDependencies": {
         "vue": "^2.6.14",
@@ -12298,11 +12298,11 @@
       }
     },
     "node_modules/druxt-router": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/druxt-router/-/druxt-router-0.24.1.tgz",
-      "integrity": "sha512-Rkp+2E4WH9LLJJE2otinoBjI9kTXOFris5lA058sYq3LejWtA/JqfOTq4rv9wmWt2rUa3NBGqO9gdvB5FthUNQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/druxt-router/-/druxt-router-0.24.2.tgz",
+      "integrity": "sha512-B/ieerVQ2yf/eu/xM3a7/hNsOkYYsPlYV6pBFHSmJSPFUZCMUTD7JGDXr8CFMAQL2zpLp9kkD7Rerau1GJ//9g==",
       "dependencies": {
-        "druxt": "^0.14.0",
+        "druxt": "^0.15.0",
         "url-parse": "^1.4.7"
       },
       "optionalDependencies": {
@@ -12311,13 +12311,13 @@
       }
     },
     "node_modules/druxt-schema": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/druxt-schema/-/druxt-schema-0.9.1.tgz",
-      "integrity": "sha512-eRnhYi9IEf2xXw2m5J/XI3JADxqs+x9NDHuO9R6XcQbU07/IqM4D9YK97E9aw2qmjWbcQEQXIS04VqlQyeHXMw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/druxt-schema/-/druxt-schema-0.9.2.tgz",
+      "integrity": "sha512-k3tZ8fI/RaLJz28Cl/Ze79R5seAzNYPHUYCAoPmoczmg8M4TvwRGEK9BWMI7dvovMIHXFnWb+pz4ivtVR5R4nQ==",
       "dependencies": {
         "consola": "^2.15.0",
         "drupal-jsonapi-params": "^1.2.2",
-        "druxt": "^0.14.0"
+        "druxt": "^0.15.0"
       },
       "optionalDependencies": {
         "vue": "^2.6.14",
@@ -12355,19 +12355,19 @@
       }
     },
     "node_modules/druxt-site": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/druxt-site/-/druxt-site-0.10.2.tgz",
-      "integrity": "sha512-t16RC0zJu1qoLOv1Jx7YAMmSSMMfsLMhMQdFBUbGntdEOjEuF1T+oqyOYBoIUnYIzzyUzkqCkkeFWXWlBo+Rzg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/druxt-site/-/druxt-site-0.10.3.tgz",
+      "integrity": "sha512-ETo27e1JbAUUciW/L/R3L3BNU/mseACFtER8eH+kFj9DeYV0yuda00ZUHcCl785BPXWQG2KRKWG5noJnS+qatg==",
       "dependencies": {
         "drupal-jsonapi-params": "^1.2.2",
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2",
-        "druxt-breadcrumb": "^0.13.2",
-        "druxt-entity": "^0.21.3",
-        "druxt-menu": "^0.15.1",
-        "druxt-router": "^0.24.1",
-        "druxt-schema": "^0.9.1",
-        "druxt-views": "^0.16.2",
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3",
+        "druxt-breadcrumb": "^0.13.3",
+        "druxt-entity": "^0.21.4",
+        "druxt-menu": "^0.15.2",
+        "druxt-router": "^0.24.2",
+        "druxt-schema": "^0.9.2",
+        "druxt-views": "^0.17.0",
         "md5": "^2.2.1"
       },
       "optionalDependencies": {
@@ -12376,17 +12376,17 @@
       }
     },
     "node_modules/druxt-views": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/druxt-views/-/druxt-views-0.16.2.tgz",
-      "integrity": "sha512-qa4IFOh3scdU0TV3rysqXkpbPZZIHNLcGcJFPhLn+ZW/yvMATP+mVyMV1IuVffXBt41pMES7feBI/gGmKB6GVg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/druxt-views/-/druxt-views-0.17.0.tgz",
+      "integrity": "sha512-v6zZ79WRSSiYXzKOzc6flnJnF1DiUAJs2KV0RRz+I1+fd1JSk2sC++1VFMlqtWtrfoJac/9esOujl3R40XV1dg==",
       "dependencies": {
         "axios": "^0.21.1",
         "deepmerge": "^4.2.2",
         "drupal-jsonapi-params": "^1.1.12",
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2",
-        "druxt-entity": "^0.21.3",
-        "druxt-router": "^0.24.1",
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3",
+        "druxt-entity": "^0.21.4",
+        "druxt-router": "^0.24.2",
         "md5": "^2.3.0"
       },
       "optionalDependencies": {
@@ -43915,9 +43915,9 @@
       }
     },
     "druxt": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/druxt/-/druxt-0.14.0.tgz",
-      "integrity": "sha512-hMczj2prrnB4kEp8bTDJvQpYcvjRTUzbdjJuKIKmmclRkDgL8HfDKHSE0BVJPa64Jmh8sLGrIRnSkhfYJGIJNw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/druxt/-/druxt-0.15.0.tgz",
+      "integrity": "sha512-H5Q7VmXvq3naLJgRu94SsyJvQ7m3inXdvEMgLr+TpW8FEQNp3ch3oA+dPWnf2MgRpenwuzFysIWu2ZdJBr0lXw==",
       "requires": {
         "@nuxtjs/proxy": "^2.1.0",
         "axios": "^0.21.1",
@@ -43933,75 +43933,75 @@
       }
     },
     "druxt-blocks": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/druxt-blocks/-/druxt-blocks-0.14.2.tgz",
-      "integrity": "sha512-zN0PPCrvU+xuBmwyisFp+hiBw4VuRtntVh7yXb/oIUpEN8xnUfF0G83Cig9Cndd3VYO+pmpOZ16tgafCwoYo0Q==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/druxt-blocks/-/druxt-blocks-0.14.3.tgz",
+      "integrity": "sha512-S4PGxEn+soGJcslNBHNPoVw90hHu6p95N44QJmVGkC5ZoI7Se/1MKylq1QTE4KVn2SZaB77m85GbACUGj94BBA==",
       "requires": {
         "axios": "^0.21.1",
         "drupal-jsonapi-params": "^1.1.12",
-        "druxt": "^0.14.0",
-        "druxt-entity": "^0.21.3",
-        "druxt-router": "^0.24.1",
+        "druxt": "^0.15.0",
+        "druxt-entity": "^0.21.4",
+        "druxt-router": "^0.24.2",
         "vue": "^2.6.14",
         "vuex": "^3.6.2"
       }
     },
     "druxt-breadcrumb": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/druxt-breadcrumb/-/druxt-breadcrumb-0.13.2.tgz",
-      "integrity": "sha512-PMSop3QeQmsfmd4jHsWkczep7/61CEvncML1iwe8mBopH/n3j3S7KxJ6bYydJHRl8krA3JyIBoEU64GDBZjpcQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/druxt-breadcrumb/-/druxt-breadcrumb-0.13.3.tgz",
+      "integrity": "sha512-v0hmv1XPwh9pux048l307j+L2o0Fktn8eAU1t+5BJDACtbbru0Ovhei1+REk5EJteE5CIfZmVGaqpKBYyr8s4g==",
       "requires": {
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2",
-        "druxt-router": "^0.24.1",
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3",
+        "druxt-router": "^0.24.2",
         "vue": "^2.6.14",
         "vuex": "^3.6.2"
       }
     },
     "druxt-entity": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/druxt-entity/-/druxt-entity-0.21.3.tgz",
-      "integrity": "sha512-7+9AtjyA72tTDRvDYs1fqvCisM2Rv4LJCdBlTuFX1lXoyqYiipmoF1Rc8BBYTQFNRhPrx91Exl0jzymGyJwSZQ==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/druxt-entity/-/druxt-entity-0.21.4.tgz",
+      "integrity": "sha512-d8m356ym2LBAjj59LOBkX6lxdbpNh+3/jLylPbvot/TTwkgo2KhR7Y2AlRIjEKHSCs+Re5nptm3W1WF9XcArsQ==",
       "requires": {
         "deepmerge": "^4.2.2",
         "drupal-jsonapi-params": "^1.2.2",
-        "druxt": "^0.14.0",
-        "druxt-router": "^0.24.1",
-        "druxt-schema": "^0.9.1"
+        "druxt": "^0.15.0",
+        "druxt-router": "^0.24.2",
+        "druxt-schema": "^0.9.2"
       }
     },
     "druxt-menu": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/druxt-menu/-/druxt-menu-0.15.1.tgz",
-      "integrity": "sha512-d1LvMMN8lq21IA1VbveNIGmy4rld9giXzC3z/zo0O0Q2hWVZ5aj6fLXBM0UWyli2dGbXNfX84mKxDd2ojJLoZQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/druxt-menu/-/druxt-menu-0.15.2.tgz",
+      "integrity": "sha512-NzTY6gx+NkFZ9+Y8V77t9AyQvj1pdaWinqp1VeOcN6QsjHoMQ3TLKeCioLEA6qxqDZEhiwBRlHdODpItRwa6DA==",
       "requires": {
         "deepmerge": "^4.2.2",
         "drupal-jsonapi-params": "^1.1.12",
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2",
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3",
         "vue": "^2.6.14",
         "vuex": "^3.6.2"
       }
     },
     "druxt-router": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/druxt-router/-/druxt-router-0.24.1.tgz",
-      "integrity": "sha512-Rkp+2E4WH9LLJJE2otinoBjI9kTXOFris5lA058sYq3LejWtA/JqfOTq4rv9wmWt2rUa3NBGqO9gdvB5FthUNQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/druxt-router/-/druxt-router-0.24.2.tgz",
+      "integrity": "sha512-B/ieerVQ2yf/eu/xM3a7/hNsOkYYsPlYV6pBFHSmJSPFUZCMUTD7JGDXr8CFMAQL2zpLp9kkD7Rerau1GJ//9g==",
       "requires": {
-        "druxt": "^0.14.0",
+        "druxt": "^0.15.0",
         "url-parse": "^1.4.7",
         "vue": "^2.6.14",
         "vuex": "^3.6.2"
       }
     },
     "druxt-schema": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/druxt-schema/-/druxt-schema-0.9.1.tgz",
-      "integrity": "sha512-eRnhYi9IEf2xXw2m5J/XI3JADxqs+x9NDHuO9R6XcQbU07/IqM4D9YK97E9aw2qmjWbcQEQXIS04VqlQyeHXMw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/druxt-schema/-/druxt-schema-0.9.2.tgz",
+      "integrity": "sha512-k3tZ8fI/RaLJz28Cl/Ze79R5seAzNYPHUYCAoPmoczmg8M4TvwRGEK9BWMI7dvovMIHXFnWb+pz4ivtVR5R4nQ==",
       "requires": {
         "consola": "^2.15.0",
         "drupal-jsonapi-params": "^1.2.2",
-        "druxt": "^0.14.0",
+        "druxt": "^0.15.0",
         "vue": "^2.6.14",
         "vuex": "^3.6.2"
       }
@@ -44033,36 +44033,36 @@
       }
     },
     "druxt-site": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/druxt-site/-/druxt-site-0.10.2.tgz",
-      "integrity": "sha512-t16RC0zJu1qoLOv1Jx7YAMmSSMMfsLMhMQdFBUbGntdEOjEuF1T+oqyOYBoIUnYIzzyUzkqCkkeFWXWlBo+Rzg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/druxt-site/-/druxt-site-0.10.3.tgz",
+      "integrity": "sha512-ETo27e1JbAUUciW/L/R3L3BNU/mseACFtER8eH+kFj9DeYV0yuda00ZUHcCl785BPXWQG2KRKWG5noJnS+qatg==",
       "requires": {
         "drupal-jsonapi-params": "^1.2.2",
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2",
-        "druxt-breadcrumb": "^0.13.2",
-        "druxt-entity": "^0.21.3",
-        "druxt-menu": "^0.15.1",
-        "druxt-router": "^0.24.1",
-        "druxt-schema": "^0.9.1",
-        "druxt-views": "^0.16.2",
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3",
+        "druxt-breadcrumb": "^0.13.3",
+        "druxt-entity": "^0.21.4",
+        "druxt-menu": "^0.15.2",
+        "druxt-router": "^0.24.2",
+        "druxt-schema": "^0.9.2",
+        "druxt-views": "^0.17.0",
         "md5": "^2.2.1",
         "vue": "^2.6.14",
         "vuex": "^3.6.2"
       }
     },
     "druxt-views": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/druxt-views/-/druxt-views-0.16.2.tgz",
-      "integrity": "sha512-qa4IFOh3scdU0TV3rysqXkpbPZZIHNLcGcJFPhLn+ZW/yvMATP+mVyMV1IuVffXBt41pMES7feBI/gGmKB6GVg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/druxt-views/-/druxt-views-0.17.0.tgz",
+      "integrity": "sha512-v6zZ79WRSSiYXzKOzc6flnJnF1DiUAJs2KV0RRz+I1+fd1JSk2sC++1VFMlqtWtrfoJac/9esOujl3R40XV1dg==",
       "requires": {
         "axios": "^0.21.1",
         "deepmerge": "^4.2.2",
         "drupal-jsonapi-params": "^1.1.12",
-        "druxt": "^0.14.0",
-        "druxt-blocks": "^0.14.2",
-        "druxt-entity": "^0.21.3",
-        "druxt-router": "^0.24.1",
+        "druxt": "^0.15.0",
+        "druxt-blocks": "^0.14.3",
+        "druxt-entity": "^0.21.4",
+        "druxt-router": "^0.24.2",
         "md5": "^2.3.0",
         "vue": "^2.6.14",
         "vuex": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "core-js": "3.18.3",
     "css-loader": "5.2.7",
     "druxt-search": "0.1.1",
-    "druxt-site": "0.10.2",
+    "druxt-site": "^0.10.3",
     "jsonapi-serializer": "3.6.7",
     "nuxt": "2.15.8",
     "vue-json-pretty": "1.8.1",


### PR DESCRIPTION
Update Druxt to 0.15.0

<a href="https://gitpod.io/#https://github.com/druxt/demo.druxtjs.org/pull/350"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

