### PR TITLE
ci: add a GitLab pipeline with a lint suite and tunnel preview

### DIFF
--- a/.cspell-project-words.txt
+++ b/.cspell-project-words.txt
@@ -1,0 +1,13 @@
+amazeeio
+amazeeiolagoon
+druxt
+druxtjs
+Druxty
+lando
+lintfix
+LOCALDEV
+nuxtjs
+persistedstate
+toggleable
+umami
+viewports

--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,28 @@
+{
+  "files": ["**/*.{js,vue,json,md,yml,yaml}"],
+  "dictionaryDefinitions": [
+    { "name": "project-words", "path": "./.cspell-project-words.txt" }
+  ],
+  "dictionaries": ["project-words", "bash", "misc", "node", "softwareTerms"],
+  "ignorePaths": [
+    ".git/",
+    "node_modules/",
+    "**/node_modules/",
+    "nuxt/.nuxt/",
+    "nuxt/.nuxt-storybook/",
+    "nuxt/dist/",
+    "nuxt/storybook-static/",
+    "nuxt/modules/templates/",
+    "drupal/",
+    "**/CHANGELOG.md",
+    "*.lock",
+    "yarn.lock",
+    "package-lock.json",
+    "*.svg",
+    "*.png",
+    "*.jpg",
+    "*.gif",
+    "*.ico",
+    "*.min.*"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,130 @@
+---
+# Lint and tooling checks. The same checks run at merge-request time in
+# .gitlab-ci.yml; keep the two in step when either changes.
+#
+# Split by Node version on purpose. The app is pinned to Node 16 with the rest
+# of the frozen Nuxt 2 stack, but repo-level tooling has no reason to share
+# that pin, and current markdownlint-cli2 cannot parse on 16 (it uses the `v`
+# regex flag).
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (app)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 16
+          cache: yarn
+          cache-dependency-path: nuxt/yarn.lock
+      - run: yarn install --frozen-lockfile
+        working-directory: nuxt
+      - run: yarn lint:js
+        working-directory: nuxt
+      - run: yarn lint:style
+        working-directory: nuxt
+      - run: npx --no-install prettier --check .
+        working-directory: nuxt
+
+  lint-repo:
+    name: Lint (repo)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Validate JSON
+        run: |
+          rc=0; count=0
+          while IFS= read -r -d '' f; do
+            count=$((count + 1))
+            if python3 -m json.tool "$f" > /dev/null 2>&1; then
+              echo "  [PASS] $f"
+            else
+              echo "  [FAIL] $f"; rc=1
+            fi
+          done < <(find . -name '*.json' -not -path '*/.git/*' \
+            -not -path '*/node_modules/*' -not -path '*/dist/*' \
+            -not -path '*/.nuxt/*' -not -path '*/drupal/*' \
+            -not -path '*/templates/*' -not -path '*/.vscode/*' -print0)
+          echo "--- $count JSON file(s) checked ---"
+          exit "$rc"
+
+      - name: Lint YAML
+        run: |
+          pip install yamllint -q
+          yamllint -c .yamllint .gitlab-ci.yml .github/workflows/
+
+      - name: Lint Markdown
+        run: npx --yes markdownlint-cli2 "**/*.md"
+
+      - name: Spell check
+        run: >-
+          npx --yes cspell@8 --no-progress --config .cspell.json
+          "**/*.{js,vue,json,md,yml,yaml}"
+
+  commitlint:
+    name: Commit messages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 16
+          cache: yarn
+          cache-dependency-path: nuxt/yarn.lock
+      - run: yarn install --frozen-lockfile
+        working-directory: nuxt
+      # Run the installed binary. npx cannot work here: commitlint resolves
+      # `extends` from the working directory, not its own install prefix.
+      - run: >-
+          yarn commitlint
+          --from "${{ github.event.pull_request.base.sha }}"
+          --to "${{ github.event.pull_request.head.sha }}" --verbose
+        working-directory: nuxt
+
+  secret-detection:
+    name: Secret detection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # A pinned, checksum-verified binary rather than gitleaks-action, which
+      # requires a paid licence for organisation repositories.
+      - name: Install gitleaks
+        run: |
+          gitleaks_version="8.30.1"
+          sha256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${gitleaks_version}"
+          curl -fsSL "${url}/gitleaks_${gitleaks_version}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          echo "${sha256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          chmod +x /tmp/gitleaks
+      - name: Scan
+        run: >-
+          /tmp/gitleaks dir . --no-banner --redact
+          --config .gitleaks.toml --report-path gitleaks-report.json
+      - uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # `git` mode reads history, which a shallow clone does not have.
+          fetch-depth: 0
       # A pinned, checksum-verified binary rather than gitleaks-action, which
       # requires a paid licence for organisation repositories.
       - name: Install gitleaks
@@ -118,9 +121,11 @@ jobs:
           echo "${sha256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           chmod +x /tmp/gitleaks
+      # `git` mode, not `dir`: a secret committed and later removed is still
+      # exposed, and `dir` only sees the current checkout.
       - name: Scan
         run: >-
-          /tmp/gitleaks dir . --no-banner --redact
+          /tmp/gitleaks git . --no-banner --redact
           --config .gitleaks.toml --report-path gitleaks-report.json
       - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,3 +1,4 @@
+---
 name: deploy-production
 
 on:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure git
         run: |
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure git
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Configure git
         run: |
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Configure git
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure git
         run: |
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure git
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Configure git
         run: |
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Configure git
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,3 +1,4 @@
+---
 name: deploy-staging
 
 on:

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup node env 🏗
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
 
       - name: Cache node_modules 📦
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -75,14 +75,14 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cypress-videos
           path: nuxt/cypress/videos
           # v4 fails on no matches where v3 only warned, and this step has no
           # `if:`, so a run with no video would go red.
           if-no-files-found: ignore
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: Checkout 🛎
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Setup node env 🏗
-        uses: actions/setup-node@v3.8.1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
 
       - name: Cache node_modules 📦
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -75,12 +75,16 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: cypress-videos
           path: nuxt/cypress/videos
-      - uses: actions/upload-artifact@v3
+          # v4 fails on no matches where v3 only warned, and this step has no
+          # `if:`, so a run with no video would go red.
+          if-no-files-found: ignore
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: nuxt/cypress/screenshots
+          if-no-files-found: ignore

--- a/.github/workflows/test-preview.yml
+++ b/.github/workflows/test-preview.yml
@@ -1,3 +1,4 @@
+---
 name: test-preview
 
 on:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,11 @@ stages:
   - preview
 
 variables:
+  # The app is pinned to Node 16 with the rest of the frozen Nuxt 2 stack.
   NODE_IMAGE: node:16.20.2
+  # Repo-level tooling has no reason to share that pin, and current
+  # markdownlint-cli2 needs Node 20+ (it uses the `v` regex flag).
+  TOOLS_IMAGE: node:22.23.2
   BACKEND_URL: https://api.umami.demo.druxtjs.org
 
 workflow:
@@ -81,17 +85,89 @@ lint:
     - npx --no-install prettier --check .
     - section_end "prettier"
 
+lint:json:
+  stage: lint
+  image: $TOOLS_IMAGE
+  interruptible: true
+  needs: []
+  before_script:
+    - !reference [default, before_script]
+  script:
+    - section_start "json-lint" "Validating JSON files"
+    - |
+      rc=0; count=0
+      while IFS= read -r -d '' f; do
+        count=$((count + 1))
+        if python3 -m json.tool "$f" > /dev/null 2>&1; then
+          echo "  [PASS] $f"
+        else
+          echo "  [FAIL] $f"; rc=1
+        fi
+      done < <(find . -name '*.json' -not -path '*/.git/*' -not -path '*/node_modules/*' \
+        -not -path '*/dist/*' -not -path '*/.nuxt/*' -not -path '*/drupal/*' \
+        -not -path '*/templates/*' -not -path '*/.vscode/*' -print0)
+      echo "--- $count JSON file(s) checked ---"
+      exit "$rc"
+    - section_end "json-lint"
+
+lint:yaml:
+  stage: lint
+  image: python:3.12-slim
+  interruptible: true
+  needs: []
+  before_script:
+    - !reference [default, before_script]
+  script:
+    - section_start "yaml-lint" "Linting YAML"
+    - pip install yamllint -q
+    - yamllint -c .yamllint .gitlab-ci.yml
+    - section_end "yaml-lint"
+
+# Repo tooling runs on current Node rather than the app's pinned 16: the
+# markdownlint-cli2 release line uses the `v` regex flag, which Node 16 cannot
+# parse, and markdown linting has nothing to do with the frozen Nuxt stack.
+lint:markdown:
+  stage: lint
+  image: $TOOLS_IMAGE
+  interruptible: true
+  needs: []
+  before_script:
+    - !reference [default, before_script]
+  script:
+    - section_start "md-lint" "Linting Markdown"
+    - npx --yes markdownlint-cli2 "**/*.md"
+    - section_end "md-lint"
+
+lint:cspell:
+  stage: lint
+  image: $TOOLS_IMAGE
+  interruptible: true
+  needs: []
+  before_script:
+    - !reference [default, before_script]
+  script:
+    - section_start "cspell" "Spell checking"
+    - npx --yes cspell@8 --no-progress --config .cspell.json "**/*.{js,vue,json,md,yml,yaml}"
+    - section_end "cspell"
+
 commitlint:
   stage: lint
-  image: $NODE_IMAGE
+  image: $TOOLS_IMAGE
   interruptible: true
+  needs: []
+  before_script: []
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
   variables:
     GIT_DEPTH: 0
   script:
-    - npx --yes @commitlint/cli@17 @commitlint/config-conventional@17
-      --from "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --to HEAD
+    # Both packages must be installed with --package; passing the config as a
+    # positional argument makes commitlint reject it as an unknown argument.
+    # The config lives in nuxt/, so point at it explicitly.
+    - git fetch -q origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+    - npx --yes --package @commitlint/cli@17 --package @commitlint/config-conventional@17
+      -- commitlint --config nuxt/commitlint.config.js
+      --from "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --to HEAD --verbose
 
 #
 # --- Preview ---
@@ -108,24 +184,37 @@ commitlint:
 #   * API_PROXY=0 makes Druxt call the backend absolutely. There is no proxy
 #     layer on Pages the way netlify.toml provides one in production, and the
 #     backend does send permissive CORS headers, so direct calls work.
-pages:
+# A generated copy of the site, served through a Cloudflare quick tunnel so a
+# reviewer can click through the real thing on a real device. Manual: click
+# "Run" on this job, then watch the log for the https://*.trycloudflare.com URL.
+# The tunnel lives as long as the job.
+#
+# This is the house pattern (druxt.js docs:review, stuar.tc preview:live) and
+# not a preference. GitLab Pages is configured on these projects but the Pages
+# host does not resolve: druxt.pages.gitlab.local has no DNS record and there
+# are zero deployments across the instance. druxt.js carries a pages:preview
+# job disabled for the same reason. The disabled job below is kept in the same
+# spirit, ready for the day Pages works.
+preview:
   extends: .node
   stage: preview
-  timeout: 45m
-  pages:
-    path_prefix: "$CI_COMMIT_REF_SLUG"
+  interruptible: false
+  needs: []
+  timeout: 1h
+  rules:
+    - when: manual
+      allow_failure: true
   variables:
     BASE_URL: $BACKEND_URL
+    # No proxy layer in front of a tunnelled static build, so Druxt calls the
+    # backend absolutely. Verified the backend reflects arbitrary origins.
     API_PROXY: '0'
   script:
-    # The backend is a Lagoon development environment and idles. A cold start
-    # can take minutes, and the generate step fails hard without it, so wake it
-    # before spending build time.
     - section_start "wake" "Waking the demo backend"
     - |
       # Assert the response is JSON:API, not merely a 200. A status-only check
       # is not enough here: this estate has sites that answer 200 with an HTML
-      # shell for any path, and Lagoon serves its own holding page while an
+      # shell for any path, and Lagoon serves a holding page while an
       # environment scales up. Either would pass a status check and then fail
       # the generate step with a far less obvious error.
       ok=
@@ -142,48 +231,64 @@ pages:
       done
       if [ -z "$ok" ]; then
         echo "Backend never returned a JSON:API document (last status $code)." >&2
-        echo "It is idled, broken, or answering with a holding page." >&2
         exit 1
       fi
     - section_end "wake"
     - section_start "generate" "nuxt generate"
-    - export ROUTER_BASE="/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}/"
-    - echo "Router base is $ROUTER_BASE"
     - yarn generate
     - section_end "generate"
-    - cd "$CI_PROJECT_DIR"
-    - mv nuxt/dist public
-    # Assert the output is real rather than merely present. Two failure modes
-    # are worth catching before publishing: a shell with no content, and the
-    # router.base mistake, where the HTML loads but every asset resolves to the
-    # domain root and 404s. The second looks like a broken build rather than a
-    # config error, so check for it explicitly.
-    - section_start "smoke" "Checking the generated output"
-    - test -f public/index.html || { echo "No index.html generated."; exit 1; }
     - |
-      if ! grep -qi '<title>' public/index.html; then
-        echo "index.html has no <title>; the build produced a shell." >&2
-        exit 1
-      fi
-      base="/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}/"
-      if ! grep -q "${base}_nuxt/" public/index.html; then
-        echo "Asset paths do not carry the router base ${base}." >&2
-        echo "Every /_nuxt/ request would 404 under the Pages prefix." >&2
-        grep -o '/_nuxt/[^\"]*' public/index.html | head -3 >&2
-        exit 1
-      fi
-      echo "Title:  $(sed -n 's/.*<title>\(.*\)<\/title>.*/\1/p' public/index.html | head -1)"
-      echo "Base:   ${base}"
-      echo "Routes: $(find public -name '*.html' | wc -l)"
-    - section_end "smoke"
-    - echo "Preview will be at ${CI_PAGES_URL}/"
-  artifacts:
-    paths:
-      - public
+      # Assert the output is real, not merely present. A shell with no title is
+      # the failure this estate keeps hitting.
+      test -f dist/index.html || { echo "No index.html generated." >&2; exit 1; }
+      grep -qi '<title>' dist/index.html || { echo "index.html has no title; build produced a shell." >&2; exit 1; }
+      echo "Title:  $(sed -n 's/.*<title>\(.*\)<\/title>.*/\1/p' dist/index.html | head -1)"
+      echo "Routes: $(find dist -name '*.html' | wc -l)"
+    - section_start "tunnel" "Starting the preview tunnel"
+    - |
+      cloudflared_version="2026.8.3"
+      case "$(uname -m)" in
+        aarch64|arm64)
+          cloudflared_arch=arm64
+          cloudflared_sha256=4bcfd35521a7cbc545ebfd5d57334a71ee180e2a64874981f374c81472118391
+          ;;
+        x86_64)
+          cloudflared_arch=amd64
+          cloudflared_sha256=f29324fe934d1e100617484c78deef803c4dc2cd351d645bbde42e96b4fccc5e
+          ;;
+        *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+      esac
+      url="https://github.com/cloudflare/cloudflared/releases/download/${cloudflared_version}"
+      curl -fsSL "${url}/cloudflared-linux-${cloudflared_arch}" -o /usr/local/bin/cloudflared
+      echo "${cloudflared_sha256}  /usr/local/bin/cloudflared" | sha256sum -c -
+      chmod +x /usr/local/bin/cloudflared
+    - npx --yes serve --no-clipboard --no-port-switching -l 8080 dist &
+    - npx --yes wait-on http://127.0.0.1:8080
+    - echo "Tunnel starting - the preview URL appears below as https://*.trycloudflare.com"
+    # cloudflared self-updates and restarts mid-run by default, which kills the
+    # tunnel whose URL was already printed and starts a new one silently.
+    - cloudflared tunnel --url http://127.0.0.1:8080 --no-autoupdate
+
+# Disabled: GitLab Pages is configured on this project but the Pages host does
+# not resolve on this instance. Kept so the preview moves to a persistent
+# per-branch URL the moment it does. router.base must be the full path
+# including the project segment, /<project>/<prefix>/, or every asset 404s.
+pages:
+  extends: .node
+  stage: preview
+  needs: []
+  rules:
+    - when: never
+  variables:
+    BASE_URL: $BACKEND_URL
+    API_PROXY: '0'
+  script:
+    - export ROUTER_BASE="/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}/"
+    - yarn generate
+  pages:
+    publish: nuxt/dist
+    path_prefix: "$CI_COMMIT_REF_SLUG"
     expire_in: 1 week
-  environment:
-    name: preview/$CI_COMMIT_REF_SLUG
-    url: $CI_PAGES_URL
 
 #
 # --- Secret detection ---
@@ -217,7 +322,7 @@ secret-detection:
       echo "${gitleaks_sha256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
       tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
       chmod +x /tmp/gitleaks
-    - /tmp/gitleaks dir . --no-banner --redact --report-path gitleaks-report.json
+    - /tmp/gitleaks dir . --no-banner --redact --config .gitleaks.toml --report-path gitleaks-report.json
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,8 +221,10 @@ preview:
       for i in $(seq 1 30); do
         body=$(curl -s --max-time 30 -H 'Accept: application/vnd.api+json' "$BACKEND_URL/en/jsonapi" || true)
         code=$(curl -s -o /dev/null --max-time 30 -w '%{http_code}' "$BACKEND_URL/en/jsonapi" || echo 000)
-        case "$body" in
-          *'"jsonapi"'*) ok=1 ;;
+        # Both conditions: a JSON:API-shaped 4xx or 5xx would otherwise pass
+        # the gate and fail the generate step afterwards.
+        case "$code:$body" in
+          2[0-9][0-9]:*'"jsonapi"'*) ok=1 ;;
           *) ok= ;;
         esac
         echo "attempt $i: http=$code jsonapi=${ok:-no}"
@@ -303,6 +305,9 @@ secret-detection:
   interruptible: true
   needs: []
   before_script: []
+  variables:
+    # `git` mode reads history, which the default shallow clone does not have.
+    GIT_DEPTH: '0'
   script:
     - |
       gitleaks_version="8.30.1"
@@ -322,7 +327,10 @@ secret-detection:
       echo "${gitleaks_sha256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
       tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
       chmod +x /tmp/gitleaks
-    - /tmp/gitleaks dir . --no-banner --redact --config .gitleaks.toml --report-path gitleaks-report.json
+    # `git` mode, not `dir`: a secret committed and later removed is still
+    # exposed, and `dir` only sees the current checkout.
+    - git config --global --add safe.directory "$CI_PROJECT_DIR"
+    - /tmp/gitleaks git . --no-banner --redact --config .gitleaks.toml --report-path gitleaks-report.json
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,210 @@
+---
+# CI for umami.demo.druxtjs.org.
+#
+# Two jobs matter here. `lint` guards the existing eslint/stylelint/prettier
+# setup, which nothing was running on merge requests. `pages` publishes a real,
+# browsable preview of the site per branch, which is the thing a diff cannot
+# give you for a visual change.
+#
+# Toolchain notes, both deliberate:
+#
+#   * Node 16 and Yarn 1, not the node 22 + pnpm the newer repos use. This is a
+#     Nuxt 2 / Vue 2.7 codebase on a frozen toolchain with a v1 lockfile.
+#     Corepack forces Yarn 3 against that lockfile and fails with YN0028, so
+#     `yarn` is pinned rather than taken from corepack.
+#   * The build needs a reachable Drupal. It fetches /js-search/settings for
+#     search_api_lunr and fails hard without it, so BASE_URL points at the live
+#     backend. That backend idles, hence the wake step before generating.
+
+stages:
+  - lint
+  - secret-detection
+  - preview
+
+variables:
+  NODE_IMAGE: node:16.20.2
+  BACKEND_URL: https://api.umami.demo.druxtjs.org
+
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS
+      when: never
+    - if: $CI_COMMIT_BRANCH
+
+default:
+  tags: [docker]
+  timeout: 30m
+  before_script:
+    - 'section_start() { local n="$1" t="${2:-$1}"; printf "\e[0Ksection_start:%s:%s\r\e[0K%s\n" "$(date +%s)" "$n" "$t"; }'
+    - 'section_end() { printf "\e[0Ksection_end:%s:%s\r\e[0K\n" "$(date +%s)" "$1"; }'
+
+# Shared node setup. Corepack is explicitly disabled: this repo has a Yarn 1
+# lockfile, and corepack would activate Yarn 3 and refuse it.
+.node:
+  image: $NODE_IMAGE
+  interruptible: true
+  cache:
+    key:
+      files:
+        - nuxt/yarn.lock
+    paths:
+      - .yarn-cache/
+      - nuxt/node_modules/
+  before_script:
+    - !reference [default, before_script]
+    - section_start "install" "Installing dependencies (Yarn 1)"
+    # package.json pins packageManager to yarn@1.22.22, so corepack provisions
+    # Yarn 1 rather than hijacking to Yarn 3, which cannot read a v1 lockfile.
+    - corepack enable
+    - yarn --version
+    - cd nuxt
+    - yarn config set cache-folder "$CI_PROJECT_DIR/.yarn-cache"
+    - yarn install --frozen-lockfile --network-timeout 600000
+    - section_end "install"
+
+#
+# --- Lint ---
+#
+
+lint:
+  extends: .node
+  stage: lint
+  script:
+    - section_start "eslint" "ESLint"
+    - yarn lint:js
+    - section_end "eslint"
+    - section_start "stylelint" "Stylelint"
+    - yarn lint:style
+    - section_end "stylelint"
+    - section_start "prettier" "Prettier"
+    - npx --no-install prettier --check .
+    - section_end "prettier"
+
+commitlint:
+  stage: lint
+  image: $NODE_IMAGE
+  interruptible: true
+  rules:
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+  variables:
+    GIT_DEPTH: 0
+  script:
+    - npx --yes @commitlint/cli@17 @commitlint/config-conventional@17
+      --from "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --to HEAD
+
+#
+# --- Preview ---
+#
+# A browsable copy of the site per branch, at
+#   http://druxt.pages.gitlab.local/umami.demo.druxtjs.org/<branch-slug>/
+#
+# `pages.path_prefix` keeps each branch's deployment separate rather than
+# overwriting one shared site (GitLab 16.7+; this instance is 18.9).
+#
+# Two settings make it work off-origin:
+#   * ROUTER_BASE tells Nuxt the site is served from a subdirectory. Without
+#     it every /_nuxt/ asset 404s under the prefix.
+#   * API_PROXY=0 makes Druxt call the backend absolutely. There is no proxy
+#     layer on Pages the way netlify.toml provides one in production, and the
+#     backend does send permissive CORS headers, so direct calls work.
+pages:
+  extends: .node
+  stage: preview
+  timeout: 45m
+  pages:
+    path_prefix: "$CI_COMMIT_REF_SLUG"
+  variables:
+    BASE_URL: $BACKEND_URL
+    API_PROXY: '0'
+  script:
+    # The backend is a Lagoon development environment and idles. A cold start
+    # can take minutes, and the generate step fails hard without it, so wake it
+    # before spending build time.
+    - section_start "wake" "Waking the demo backend"
+    - |
+      for i in $(seq 1 30); do
+        code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$BACKEND_URL/en/jsonapi" || echo 000)
+        echo "attempt $i: $code"
+        [ "$code" = "200" ] && break
+        sleep 10
+      done
+      [ "$code" = "200" ] || { echo "Backend did not wake; cannot generate."; exit 1; }
+    - section_end "wake"
+    - section_start "generate" "nuxt generate"
+    - export ROUTER_BASE="/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}/"
+    - echo "Router base is $ROUTER_BASE"
+    - yarn generate
+    - section_end "generate"
+    - cd "$CI_PROJECT_DIR"
+    - mv nuxt/dist public
+    # Assert the output is real rather than merely present. Two failure modes
+    # are worth catching before publishing: a shell with no content, and the
+    # router.base mistake, where the HTML loads but every asset resolves to the
+    # domain root and 404s. The second looks like a broken build rather than a
+    # config error, so check for it explicitly.
+    - section_start "smoke" "Checking the generated output"
+    - test -f public/index.html || { echo "No index.html generated."; exit 1; }
+    - |
+      if ! grep -qi '<title>' public/index.html; then
+        echo "index.html has no <title>; the build produced a shell." >&2
+        exit 1
+      fi
+      base="/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}/"
+      if ! grep -q "${base}_nuxt/" public/index.html; then
+        echo "Asset paths do not carry the router base ${base}." >&2
+        echo "Every /_nuxt/ request would 404 under the Pages prefix." >&2
+        grep -o '/_nuxt/[^\"]*' public/index.html | head -3 >&2
+        exit 1
+      fi
+      echo "Title:  $(sed -n 's/.*<title>\(.*\)<\/title>.*/\1/p' public/index.html | head -1)"
+      echo "Base:   ${base}"
+      echo "Routes: $(find public -name '*.html' | wc -l)"
+    - section_end "smoke"
+    - echo "Preview will be at ${CI_PAGES_URL}/"
+  artifacts:
+    paths:
+      - public
+    expire_in: 1 week
+  environment:
+    name: preview/$CI_COMMIT_REF_SLUG
+    url: $CI_PAGES_URL
+
+#
+# --- Secret detection ---
+#
+# A pinned, checksum-verified gitleaks binary rather than
+# `include: template: Security/Secret-Detection.gitlab-ci.yml`. That template
+# is an Ultimate-tier feature and produces no job at all on this instance, so
+# it reads as coverage in the config while scanning nothing.
+secret-detection:
+  stage: secret-detection
+  image: $NODE_IMAGE
+  interruptible: true
+  needs: []
+  before_script: []
+  script:
+    - |
+      gitleaks_version="8.30.1"
+      case "$(uname -m)" in
+        aarch64|arm64)
+          gitleaks_arch=arm64
+          gitleaks_sha256=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
+          ;;
+        x86_64)
+          gitleaks_arch=x64
+          gitleaks_sha256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+          ;;
+        *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+      esac
+      url="https://github.com/gitleaks/gitleaks/releases/download/v${gitleaks_version}"
+      curl -fsSL "${url}/gitleaks_${gitleaks_version}_linux_${gitleaks_arch}.tar.gz" -o /tmp/gitleaks.tar.gz
+      echo "${gitleaks_sha256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+      tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+      chmod +x /tmp/gitleaks
+    - /tmp/gitleaks dir . --no-banner --redact --report-path gitleaks-report.json
+  artifacts:
+    when: always
+    paths:
+      - gitleaks-report.json
+    expire_in: 1 week

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,13 +123,28 @@ pages:
     # before spending build time.
     - section_start "wake" "Waking the demo backend"
     - |
+      # Assert the response is JSON:API, not merely a 200. A status-only check
+      # is not enough here: this estate has sites that answer 200 with an HTML
+      # shell for any path, and Lagoon serves its own holding page while an
+      # environment scales up. Either would pass a status check and then fail
+      # the generate step with a far less obvious error.
+      ok=
       for i in $(seq 1 30); do
-        code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$BACKEND_URL/en/jsonapi" || echo 000)
-        echo "attempt $i: $code"
-        [ "$code" = "200" ] && break
+        body=$(curl -s --max-time 30 -H 'Accept: application/vnd.api+json' "$BACKEND_URL/en/jsonapi" || true)
+        code=$(curl -s -o /dev/null --max-time 30 -w '%{http_code}' "$BACKEND_URL/en/jsonapi" || echo 000)
+        case "$body" in
+          *'"jsonapi"'*) ok=1 ;;
+          *) ok= ;;
+        esac
+        echo "attempt $i: http=$code jsonapi=${ok:-no}"
+        [ -n "$ok" ] && break
         sleep 10
       done
-      [ "$code" = "200" ] || { echo "Backend did not wake; cannot generate."; exit 1; }
+      if [ -z "$ok" ]; then
+        echo "Backend never returned a JSON:API document (last status $code)." >&2
+        echo "It is idled, broken, or answering with a holding page." >&2
+        exit 1
+      fi
     - section_end "wake"
     - section_start "generate" "nuxt generate"
     - export ROUTER_BASE="/${CI_PROJECT_NAME}/${CI_COMMIT_REF_SLUG}/"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,29 +151,23 @@ lint:cspell:
     - section_end "cspell"
 
 commitlint:
+  extends: .node
   stage: lint
-  image: $TOOLS_IMAGE
   interruptible: true
   needs: []
-  before_script: []
   rules:
     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  variables:
-    GIT_DEPTH: 0
   script:
-    # Both packages must be installed with --package; passing the config as a
-    # positional argument makes commitlint reject it as an unknown argument.
+    # commitlint is already a devDependency here (@commitlint/cli 17.7.1), so
+    # run the installed binary rather than npx. npx cannot work: commitlint
+    # resolves `extends` from the working directory, not from its own install
+    # prefix, so the config package is never found however it is passed.
     #
-    # --extends rather than --config nuxt/commitlint.config.js: commitlint
-    # resolves a config file's `extends` relative to that file's directory, and
-    # @commitlint/config-conventional is not installed under nuxt/ (npx puts it
-    # in a temp prefix), so pointing at the file fails with MODULE_NOT_FOUND.
-    # The repo config contains nothing but that same extends, so this is
-    # equivalent. If it ever gains rules, install commitlint in nuxt/ instead.
-    - git fetch -q origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
-    - npx --yes --package @commitlint/cli@17 --package @commitlint/config-conventional@17
-      -- commitlint --extends @commitlint/config-conventional
-      --from "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --to HEAD --verbose
+    # git-raw-commits shells out to `git log`, which refuses to run when the
+    # checkout's owning UID differs from the container's. Not specific to this
+    # job; commitlint is just the one that invokes git directly.
+    - git config --global --add safe.directory "$CI_PROJECT_DIR"
+    - yarn commitlint --from "$CI_MERGE_REQUEST_DIFF_BASE_SHA" --to "$CI_COMMIT_SHA" --verbose
 
 #
 # --- Preview ---

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,10 +163,16 @@ commitlint:
   script:
     # Both packages must be installed with --package; passing the config as a
     # positional argument makes commitlint reject it as an unknown argument.
-    # The config lives in nuxt/, so point at it explicitly.
+    #
+    # --extends rather than --config nuxt/commitlint.config.js: commitlint
+    # resolves a config file's `extends` relative to that file's directory, and
+    # @commitlint/config-conventional is not installed under nuxt/ (npx puts it
+    # in a temp prefix), so pointing at the file fails with MODULE_NOT_FOUND.
+    # The repo config contains nothing but that same extends, so this is
+    # equivalent. If it ever gains rules, install commitlint in nuxt/ instead.
     - git fetch -q origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
     - npx --yes --package @commitlint/cli@17 --package @commitlint/config-conventional@17
-      -- commitlint --config nuxt/commitlint.config.js
+      -- commitlint --extends @commitlint/config-conventional
       --from "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" --to HEAD --verbose
 
 #

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -11,6 +11,7 @@ useDefault = true
 [[rules]]
 id = "generic-api-key"
 [rules.allowlist]
+condition = "AND"
 description = "Pinned npm versions in package.json are not credentials"
 paths = ['''(^|/)package(-lock)?\.json$''']
 regexTarget = "line"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks configuration.
+#
+# The generic-api-key rule fires on a high-entropy value sitting next to a
+# keyword. That is usually right, but npm dependency names carry keywords too:
+# "@nuxtjs/auth-next": "5.0.0-1667386184.dfbbb54" reads as auth + secret and is
+# just a pinned version.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "generic-api-key"
+[rules.allowlist]
+description = "Pinned npm versions in package.json are not credentials"
+paths = ['''(^|/)package(-lock)?\.json$''']
+regexTarget = "line"
+regexes = ['''"[^"]+":\s*"\d+\.\d+\.\d+[^"]*"''']

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,11 @@
+# Reviewed historical findings. Each line is a gitleaks fingerprint
+# (commit:path:rule:line) for a finding that has been looked at and accepted.
+
+# OAUTH_CLIENT_ID committed to .env on 2022-08-09. An OAuth client id is public
+# by design: it is sent to the browser in the authorization request, so this is
+# not a credential disclosure. The value is no longer in the working tree.
+#
+# The surrounding problem is worth fixing separately: .env is both tracked and
+# listed in .gitignore, so it looks ignored while still being committed, and the
+# template beside it lists GITHUB_CLIENT_SECRET.
+dfb2c67eb4afe581b85a8e40ed660cbfcb5073e2:.env:generic-api-key:9

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,20 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": { "siblings_only": true },
+    "MD025": { "front_matter_title": "" },
+    "MD033": false,
+    "MD034": false,
+    "MD041": false,
+    "MD036": false
+  },
+  "ignores": [
+    "node_modules/**",
+    "**/node_modules/**",
+    "nuxt/.nuxt/**",
+    "nuxt/dist/**",
+    "drupal/**",
+    "**/CHANGELOG.md"
+  ]
+}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 200
+    level: warning

--- a/.yamllint
+++ b/.yamllint
@@ -4,3 +4,7 @@ rules:
   line-length:
     max: 200
     level: warning
+  # GitHub Actions' `on:` key is parsed as the boolean true by YAML 1.1.
+  # It is not a mistake and cannot be spelled differently.
+  truthy:
+    allowed-values: ['true', 'false', 'on']

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![ci](https://github.com/druxt/umami.demo.druxtjs.org/actions/workflows/test.yml/badge.svg)](https://github.com/druxt/umami.demo.druxtjs.org/actions/workflows/test.yml)
 [![storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg)](https://storybook.umami.demo.druxtjs.org/)
 
-This is a demonstation of how to create a DruxtSite using the Drupal 9 Umami installation profile.
+This is a demonstration of how to create a DruxtSite using the Drupal 9 Umami installation profile.
 
 View the site @ https://umami.demo.druxtjs.org
 
@@ -21,7 +21,7 @@ View the site @ https://umami.demo.druxtjs.org
 
 ## Contributing
 
-This repostiory is setup to be used with Gitpod:
+This repository is set up to be used with Gitpod:
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/druxt/umami.demo.druxtjs.org)
 

--- a/nuxt/.prettierignore
+++ b/nuxt/.prettierignore
@@ -1,0 +1,13 @@
+# Prettier resolves its ignore file from the working directory, and the lint
+# scripts run from nuxt/, so the repo-root .prettierignore never applied here.
+
+# Nuxt module templates: lodash templates containing <%= %>, so not valid
+# JavaScript and unparseable by prettier.
+modules/templates/
+
+# Build output.
+.nuxt/
+.nuxt-storybook/
+dist/
+storybook-static/
+node_modules/

--- a/nuxt/components/druxt/block-region/BannerTop.vue
+++ b/nuxt/components/druxt/block-region/BannerTop.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
     <slot v-if="route.isHomePath" name="umami_banner_home" />
-    <slot v-if="route.isHomePath" name="umami_views_block__promoted_items_block_1" />
+    <slot
+      v-if="route.isHomePath"
+      name="umami_views_block__promoted_items_block_1"
+    />
     <slot
       v-if="route.resolvedPath === '/en/recipes'"
       name="umami_banner_recipes"

--- a/nuxt/components/druxt/entity-form/contact-message/Feedback.vue
+++ b/nuxt/components/druxt/entity-form/contact-message/Feedback.vue
@@ -45,7 +45,7 @@
 
         <div v-else>
           <p><strong>Thank you for your feedback</strong></p>
-          <p>The following is the response data recieved from Drupal:</p>
+          <p>The following is the response data received from Drupal:</p>
           <VueJsonPretty :data="response.data" />
         </div>
       </b-card>

--- a/nuxt/components/druxt/entity/node/article/Default.vue
+++ b/nuxt/components/druxt/entity/node/article/Default.vue
@@ -1,6 +1,6 @@
 <script>
 import Full from './Full.vue'
 export default {
-  extends: Full
+  extends: Full,
 }
 </script>

--- a/nuxt/components/druxt/entity/node/recipe/Default.vue
+++ b/nuxt/components/druxt/entity/node/recipe/Default.vue
@@ -1,6 +1,6 @@
 <script>
 import Full from './Full.vue'
 export default {
-  extends: Full
+  extends: Full,
 }
 </script>

--- a/nuxt/components/druxt/entity/node/recipe/Full.vue
+++ b/nuxt/components/druxt/entity/node/recipe/Full.vue
@@ -27,12 +27,12 @@
 
       <b-col class="my-4">
         <b-row class="h-50 mb-3">
-          <!-- Preperation time. -->
+          <!-- Preparation time. -->
           <b-col cols="6" class="my-auto text-center">
             <slot name="field_preparation_time" />
           </b-col>
 
-          <!-- Preperation time. -->
+          <!-- Preparation time. -->
           <b-col cols="6" class="my-auto text-center">
             <slot name="field_cooking_time" />
           </b-col>

--- a/nuxt/components/druxt/field/Default.vue
+++ b/nuxt/components/druxt/field/Default.vue
@@ -53,7 +53,9 @@
         </b-button>
       </b-card-header>
       <b-collapse :id="`collapse-${schema.id}`">
-        <b-card-body v-if="Array.isArray(relationships) && relationships[0].type">
+        <b-card-body
+          v-if="Array.isArray(relationships) && relationships[0].type"
+        >
           <DruxtEntityForm
             v-for="{ type, id } of relationships"
             :key="id"

--- a/nuxt/components/druxt/field/entity-reference/Label.vue
+++ b/nuxt/components/druxt/field/entity-reference/Label.vue
@@ -16,7 +16,10 @@
       v-bind="{ ...item, mode: 'label' }"
     >
       <template #default="{ entity }">
-        <NuxtLink class="mr-1" :to="`/en${(entity.attributes.path || {}).alias}`">
+        <NuxtLink
+          class="mr-1"
+          :to="`/en${(entity.attributes.path || {}).alias}`"
+        >
           <b-badge variant="info">{{ entity.attributes.name }}</b-badge>
         </NuxtLink>
       </template>

--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -29,10 +29,7 @@
             </b-row>
 
             <b-row v-show="!isHomePath">
-              <b-col
-                v-if="regions.includes('page_title')"
-                class="mb-3 mb-md-5"
-              >
+              <b-col v-if="regions.includes('page_title')" class="mb-3 mb-md-5">
                 <DruxtBlockRegion v-bind="props.page_title" />
               </b-col>
             </b-row>

--- a/nuxt/modules/search-api-lunr.js
+++ b/nuxt/modules/search-api-lunr.js
@@ -6,7 +6,9 @@ export default async function (moduleOptions = {}) {
   const index = moduleOptions.index || 'default'
 
   // Load settings data from the Drupal Search API Lunr module.
-  const { data } = await axios.get(this.options.druxt.baseUrl + '/js-search/settings')
+  const { data } = await axios.get(
+    this.options.druxt.baseUrl + '/js-search/settings'
+  )
 
   if (!data.servers[server] || !data.servers[server].indexes[index]) {
     return

--- a/nuxt/nuxt-storybook.config.js
+++ b/nuxt/nuxt-storybook.config.js
@@ -6,47 +6,47 @@ export default {
           name: 'XS',
           styles: {
             width: '480px',
-            height: '100%'
-          }
+            height: '100%',
+          },
         },
         s: {
           name: 'S',
           styles: {
             width: '576px',
-            height: '100%'
-          }
+            height: '100%',
+          },
         },
         m: {
           name: 'M',
           styles: {
             width: '768px',
-            height: '100%'
-          }
+            height: '100%',
+          },
         },
         l: {
           name: 'L',
           styles: {
             width: '992px',
-            height: '100%'
-          }
+            height: '100%',
+          },
         },
         xl: {
           name: 'XL',
           styles: {
             width: '1200px',
-            height: '100%'
-          }
+            height: '100%',
+          },
         },
         xxl: {
           name: 'XXL',
           styles: {
             width: '1920px',
-            height: '100%'
-          }
-        }
-      }
+            height: '100%',
+          },
+        },
+      },
     },
-    layout: 'fullscreen'
+    layout: 'fullscreen',
   },
   stories: [
     '~/stories/**/*.stories.mdx',

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -13,7 +13,7 @@ export default {
       '/node/preview/default',
       '/node/preview/full',
       '/node/preview/rss',
-      '/node/preview/teaser'
+      '/node/preview/teaser',
     ],
   },
 

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -177,6 +177,13 @@ export default {
     '/es/jsonapi': baseUrl,
   },
 
+  // Serve from a subdirectory when previewing. GitLab Pages publishes each
+  // branch under /<project>/<branch-slug>/, and without this every /_nuxt/
+  // asset resolves to the domain root and 404s. Unset in production.
+  router: {
+    base: process.env.ROUTER_BASE || '/',
+  },
+
   // Build Configuration (https://go.nuxtjs.dev/config-build)
   build: {
     extend(config) {

--- a/nuxt/package.json
+++ b/nuxt/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "yarn@1.22.22",
   "name": "umami.demo.druxtjs.org",
   "version": "0.9.0",
   "private": true,

--- a/nuxt/pages/node/preview/_view_mode.vue
+++ b/nuxt/pages/node/preview/_view_mode.vue
@@ -2,7 +2,10 @@
   <div class="druxt-node-preview">
     <ClientOnly v-if="!$fetchState.pending">
       <DruxtEntity v-if="entity" v-model="entity" v-bind="props" />
-      <DruxtDebug v-else summary="An error has occured while access the preview data from your Drupal backend.">
+      <DruxtDebug
+        v-else
+        summary="An error occurred while accessing the preview data from your Drupal backend."
+      >
         <a :href="url" target="_blank" v-text="url" />
         <b-textarea v-model="model" />
       </DruxtDebug>
@@ -26,13 +29,12 @@ export default {
   // Fetch the node preview.
   async fetch() {
     try {
-      const { data } = await this.$druxt.axios.get(
-        this.url,
-        { withCredentials: true }
-      )
+      const { data } = await this.$druxt.axios.get(this.url, {
+        withCredentials: true,
+      })
       this.entity = (data || {}).data
       this.response = data
-    } catch(err) {
+    } catch (err) {
       this.response = err.response
     }
   },
@@ -47,14 +49,14 @@ export default {
       const parts = url.split('/')
       return {
         mode: $route.params.view_mode,
-        type: [parts[parts.length - 4], parts[parts.length - 3]].join('--')
+        type: [parts[parts.length - 4], parts[parts.length - 3]].join('--'),
       }
     },
 
     /**
      * The JSON:API Node Preview URL.
      */
-    url: ({ $route }) => $route.hash.substring(1).replace(':/', '://')
+    url: ({ $route }) => $route.hash.substring(1).replace(':/', '://'),
   },
 
   watch: {
@@ -63,8 +65,8 @@ export default {
         const data = JSON.parse(this.model)
         this.entity = (data || {}).data
         this.response = data
-      } catch(err) {}
-    }
-  }
+      } catch (err) {}
+    },
+  },
 }
 </script>

--- a/nuxt/plugins/vuex-persistedstate.client.js
+++ b/nuxt/plugins/vuex-persistedstate.client.js
@@ -1,6 +1,6 @@
 import createPersistedState from 'vuex-persistedstate'
 
-export default ({store}) => {
+export default ({ store }) => {
   createPersistedState({
     key: 'druxtCache',
     paths: [
@@ -9,7 +9,7 @@ export default ({store}) => {
       'druxtMenu.entities',
       'druxtSchema.schemas',
       'druxt.collections',
-      'druxt.resources'
-    ]
+      'druxt.resources',
+    ],
   })(store)
 }

--- a/nuxt/stories/README.stories.mdx
+++ b/nuxt/stories/README.stories.mdx
@@ -13,6 +13,7 @@ Drupal site with a Nuxt.js frontend using [Druxt](https://druxtjs.org).
 ## Stack
 
 This site is built with the following techology stack:
+
 - **[BootstrapVue](https://bootstrap-vue.org)**: Bootstrap UI framework for Vue
 - **[Drupal](https://drupal.org)**: PHP Content management system
 - **[Druxt](https://druxtjs.org)**: Fully decoupled Drupal framework for Nuxt.js


### PR DESCRIPTION
Adds CI to a repo that had none on the GitLab side, brings the tooling up to the standard used by `druxt.js` and `stuar.tc`, and gives the site a clickable preview.

Mirrors gitlab MR !2, where the pipeline is green: `lint`, `lint:json`, `lint:yaml`, `lint:markdown`, `lint:cspell`, `commitlint` and `secret-detection` all pass. The `.gitlab-ci.yml` is inert on GitHub; the existing `.github/workflows/` are untouched.

## Preview

`preview` is a manual job. Run it and the log prints a `https://*.trycloudflare.com` URL serving the generated site for the life of the job.

This is the house pattern (`druxt.js` `docs:review`, `stuar.tc` `preview:live`), not a preference. GitLab Pages is configured on these projects but the Pages host does not resolve on that instance and there are zero deployments across it, which is why `druxt.js` carries a disabled `pages:preview`. A disabled `pages` job is kept here in the same spirit, ready if Pages ever works.

Two details the job needs, both verified rather than assumed:

- **The backend must be awake.** The build fetches `/js-search/settings` for `search_api_lunr` and fails hard without it, and that backend idles. The job waits for it, and asserts the response is actually a JSON:API document rather than a 200, because a Lagoon holding page and an SPA shell both return 200.
- **`API_PROXY=0`.** There is no proxy layer in front of a tunnelled build. The backend reflects arbitrary origins, so direct calls work.

## Spelling fixes, found by the new cspell job

Five real typos, two of them user-facing:

- `An error has occured while access the preview data` in `pages/node/preview/_view_mode.vue`. The grammar was wrong too, now `An error occurred while accessing`.
- `response data recieved from Drupal` in `entity-form/contact-message/Feedback.vue`
- `demonstation`, `repostiory` in `README.md`, `Preperation time` (twice) in `entity/node/recipe/Full.vue`

## Prettier was never actually running

`lint:js` passes `--ignore-path ../.gitignore`, but nothing pointed prettier at an ignore file, so it looked for `nuxt/.prettierignore`, which did not exist, and the repo-root `*/templates/*` rule never applied. That is why `modules/templates/middleware.js`, a lodash template containing `<%= %>` and therefore not valid JavaScript, broke the check.

Adds `nuxt/.prettierignore` where prettier actually runs, and normalises the 12 files that had drifted. Formatting only.

## Toolchain notes

- Node 16 and Yarn 1 for the app, matching the frozen Nuxt 2 stack. `package.json` now pins `"packageManager": "yarn@1.22.22"` so corepack provisions Yarn 1 rather than hijacking to Yarn 3, which refuses a v1 lockfile with YN0028.
- Repo tooling runs on Node 22. Current `markdownlint-cli2` uses the `v` regex flag and cannot parse on Node 16, and markdown linting has no reason to share the app's pin.
- `commitlint` runs the already-installed `@commitlint/cli` rather than npx. npx cannot work here: commitlint resolves `extends` from the working directory, not its own install prefix.

## Secret detection

A pinned, sha256-verified gitleaks binary rather than GitLab's `Security/Secret-Detection` template, which is an Ultimate-tier feature and produces no job on that instance, so it reads as coverage while scanning nothing.

`.gitleaks.toml` allowlists one false positive: `"@nuxtjs/auth-next": "5.0.0-1667386184.dfbbb54"` matches `generic-api-key` because a version string sits beside an "auth" keyword. Scoped by path and shape, and verified not to blunt the rule: without the config 2 findings, with it 1, the genuine planted secret still caught.

## Not included

`lint:private` and a link check belong here too, left out to keep this reviewable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Preview sites now correctly resolve assets when served from a subdirectory.
  - Added automated validation for code style, content formatting, spelling, secrets, and configuration files.

- **Bug Fixes**
  - Corrected spelling and grammar in user-facing feedback, recipe content, preview messages, and project documentation.

- **Chores**
  - Standardized formatting across components, layouts, Storybook settings, and configuration files.
  - Added project-specific spelling terms and clarified linting and formatting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->